### PR TITLE
Mise en conformité de l'entête avec le logo institutionnel

### DIFF
--- a/site/layouts/partials/nav.html
+++ b/site/layouts/partials/nav.html
@@ -21,11 +21,9 @@
         <div class="fr-header__brand fr-enlarge-link">
           <div class="fr-header__brand-top">
             <div class="fr-header__logo">
-              <p class="fr-logo">
-                Ministère
-                <br>de la transformation
-                <br>et de la fonction
-                <br>publiques
+              <p class="fr-logo" title="République Française">
+                République
+                <br>Française
               </p>
             </div>
             <div class="fr-header__navbar">
@@ -36,19 +34,20 @@
             </div>
           </div>
           <div class="fr-header__service">
-            <a href="/" title="Accueil - Entrepreneur·e·s d'intérêt général">
-              <p class="fr-header__service-title">Entrepreneur·e·s d'intérêt général</p>
+            <a href="/" title="Accueil - Entrepreneur·e·s d’intérêt général - République Française">
+              <p class="fr-header__service-title">Entrepreneur·e·s d’intérêt général</p>
             </a>
+            <p class="fr-header__service-tagline">Un programme de la filière du numérique de l’État</p>
           </div>
         </div>
         <div class="fr-header__tools">
           <div class="fr-header__tools-links">
             <ul class="fr-links-group">
               <li>
-                <a class="fr-link fr-fi-arrow-right-line" href="{{ relref . " presse" }}">Espace Presse</a>
+                <a class="fr-link fr-fi-file-line" href="{{ relref . "presse" }}">Espace presse</a>
               </li>
               <li>
-                <a class="fr-link fr-fi-arrow-right-line" href="{{ relref . " blog" }}">Blog</a>
+                <a class="fr-link fr-fi-eye-line" href="{{ relref . "blog" }}">Blog</a>
               </li>
             </ul>
           </div>


### PR DESCRIPTION
Modifier le header pour obtenir :
- un bloc-marque République Française ;
- le titre Entrepreneur·e·s d’intérêt général ;
- le sous-titre Un programme de la filière du numérique de l’État ;
- deux liens rapides avec icônes DSFR natives :
  - Espace presse avec fr-fi-file-line ;
  - Blog avec fr-fi-eye-line.