### PR TITLE
Mise en conformité du pied de page

### DIFF
--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -2,28 +2,29 @@
   <div class="fr-container">
     <div class="fr-footer__body">
       <div class="fr-footer__brand fr-enlarge-link">
-        <a href="/" title="Retour à l’accueil">
-          <p class="fr-logo" title="république française">
-            Ministère
-            <br>de la transformation
-            <br>et de la fonction
-            <br>publiques
+        <a href="/" title="Retour à l’accueil du site - Entrepreneur·e·s d’intérêt général - République Française">
+          <p class="fr-logo" title="République Française">
+            République
+            <br>Française
           </p>
         </a>
       </div>
       <div class="fr-footer__content">
+        <p class="fr-footer__content-desc">
+          eig.numerique.gouv.fr est le site du programme Entrepreneur·e·s d'intérêt général, porté par la Direction interministérielle du numérique et intégré au réseau d’incubateurs ministériels de beta.gouv.fr.
+        </p>
         <ul class="fr-footer__content-list">
           <li class="fr-footer__content-item">
-            <a class="fr-footer__content-link" href="https://legifrance.gouv.fr" target="_blank">legifrance.gouv.fr</a>
+            <a class="fr-footer__content-link" href="https://www.info.gouv.fr" target="_blank" rel="noopener external" title="info.gouv.fr - ouvre une nouvelle fenêtre">info.gouv.fr</a>
           </li>
           <li class="fr-footer__content-item">
-            <a class="fr-footer__content-link" href="https://gouvernement.fr" target="_blank">gouvernement.fr</a>
+            <a class="fr-footer__content-link" href="https://www.service-public.fr" target="_blank" rel="noopener external" title="service-public.fr - ouvre une nouvelle fenêtre">service-public.fr</a>
           </li>
           <li class="fr-footer__content-item">
-            <a class="fr-footer__content-link" href="https://service-public.fr" target="_blank">service-public.fr</a>
+            <a class="fr-footer__content-link" href="https://www.legifrance.gouv.fr" target="_blank" rel="noopener external" title="legifrance.gouv.fr - ouvre une nouvelle fenêtre">legifrance.gouv.fr</a>
           </li>
           <li class="fr-footer__content-item">
-            <a class="fr-footer__content-link" href="https://data.gouv.fr" target="_blank">data.gouv.fr</a>
+            <a class="fr-footer__content-link" href="https://www.data.gouv.fr" target="_blank" rel="noopener external" title="data.gouv.fr - ouvre une nouvelle fenêtre">data.gouv.fr</a>
           </li>
         </ul>
       </div>
@@ -31,28 +32,26 @@
     <div class="fr-footer__bottom">
       <ul class="fr-footer__bottom-list">
         <li class="fr-footer__bottom-item">
-          <a class="fr-footer__bottom-link" href="{{ relref . " cgu.md" }}">Mentions légales</a>
+          <a class="fr-footer__bottom-link" href="{{ relref . "cgu.md" }}">Mentions légales</a>
         </li>
         <li class="fr-footer__bottom-item">
-          <a class="fr-footer__bottom-link" href="{{ relref . " accessibilite.md" }}">Accessibilité : partiellement conforme</a>
+          <a class="fr-footer__bottom-link" href="{{ relref . "accessibilite.md" }}">Accessibilité : partiellement conforme</a>
         </li>
         <li class="fr-footer__bottom-item">
-          <a class="fr-footer__bottom-link" href="{{ relref . " presse.md" }}">Revue de presse</a>
+          <a class="fr-footer__bottom-link" href="{{ relref . "presse.md" }}">Revue de presse</a>
         </li>
         <li class="fr-footer__bottom-item">
-          <a class="fr-footer__bottom-link" href="{{ relref . " plan.md" }}">Plan du site</a>
+          <a class="fr-footer__bottom-link" href="{{ relref . "plan.md" }}">Plan du site</a>
         </li>
         <li class="fr-footer__bottom-item">
-          <a class="fr-footer__bottom-link" href="{{ relref . " personal-data.md" }}">Données personnelles</a>
+          <a class="fr-footer__bottom-link" href="{{ relref . "personal-data.md" }}">Données personnelles</a>
         </li>
         <li class="fr-footer__bottom-item">
           <button class="fr-footer__bottom-link js-cookies">Gestion des cookies</button>
         </li>
       </ul>
       <div class="fr-footer__bottom-copy">
-        <p>Sauf mention contraire, tous les textes de ce site sont sous <a
-            href="https://github.com/etalab/licence-ouverte/blob/master/LO.md" target="_blank">licence etalab-2.0</a>
-        </p>
+        <p>Sauf mention contraire, tous les textes de ce site sont sous <a href="https://github.com/etalab/licence-ouverte/blob/master/LO.md" target="_blank" rel="noopener external" title="licence etalab-2.0 - ouvre une nouvelle fenêtre">licence etalab-2.0</a>.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
- Remplacement du bloc-marque `Gouvernement` par `République Française`.
- Mise à jour du texte descriptif du site et du programme EIG.
- Conservation des liens de bas de page et de la mention de licence `etalab-2.0`.