### PR TITLE
Classe fr-footer__logo

### DIFF
--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -16,7 +16,7 @@
           rel="noopener external"
           title="numerique.gouv.fr - ouvre une nouvelle fenêtre">
           <img
-            class="fr-responsive-img"
+            class="fr-footer__logo"
             src="/img/numerique-gouv.svg"
             alt="numerique.gouv">
         </a>


### PR DESCRIPTION
Classe fr-footer__logo appliquée au marqueur numerique.gouv